### PR TITLE
Modernize CMake script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Build folder
+**/build
+
+# Temporary user files
+**/CMakeLists.txt.user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,35 @@
-cmake_minimum_required(VERSION 2.8)
-project(test)
+cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+project(KCF LANGUAGES CXX)
+
+## build settings:
+
+set(CMAKE_CXX_STANDARD 11)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the build type" FORCE)
+endif()
+
+set(CMAKE_CXX_FLAGS_RELEASE -O3)
+
+## 3rd-party dependencies:
 
 find_package(OpenCV REQUIRED)
 
-if(NOT WIN32)
-ADD_DEFINITIONS("-std=c++0x -O3")
-endif(NOT WIN32)
+## executable:
 
-include_directories(src) 
-FILE(GLOB_RECURSE sourcefiles "src/*.cpp")
-add_executable( KCF ${sourcefiles} )
-target_link_libraries( KCF ${OpenCV_LIBS})
+set(sources
+  src/fhog.cpp
+  src/kcftracker.cpp
+  src/runtracker.cpp)
 
+set(headers
+  src/ffttools.hpp
+  src/fhog.hpp
+  src/kcftracker.hpp
+  src/labdata.hpp
+  src/recttools.hpp
+  src/tracker.h)
 
-
-
+add_executable(${PROJECT_NAME} ${sources} ${headers})
+target_include_directories(${PROJECT_NAME} PUBLIC src)
+target_link_libraries(${PROJECT_NAME} PUBLIC ${OpenCV_LIBS})

--- a/README.md
+++ b/README.md
@@ -24,10 +24,15 @@ Description: KCF on HOG and Lab features, ported to C++ OpenCV. The Lab features
 The CSK tracker [2] is also implemented as a bonus, simply by using raw grayscale as features (the filter becomes single-channel).   
 
 ### Compilation instructions ###
-There are no external dependencies other than OpenCV 3.0.0. Tested on a freshly installed Ubuntu 14.04.   
 
-1) cmake CMakeLists.txt   
-2) make   
+There are no external dependencies other than [OpenCV](https://opencv.org/) 3.0.0. Tested on a freshly installed Ubuntu 14.04. It is recommended to do an *out-of-source* build, as in:
+
+```shh
+KCFcpp$ mkdir build
+KCFcpp$ cd build
+KCFcpp/build$ cmake ..
+KCFcpp/build$ cmake --build .
+```
 
 ### Running instructions ###
 
@@ -45,7 +50,7 @@ fixed_window - Keep the window size fixed when in single-scale mode (multi-scale
 show - Show the results in a window.   
 
 To include it in your project, without the VOT toolkit you just need to:
-	
+
 	// Create the KCFTracker object with one of the available options
 	KCFTracker tracker(HOG, FIXEDWINDOW, MULTISCALE, LAB);
 


### PR DESCRIPTION
Hello there, in this PR I did a small refactoring on the original CMake script to give it a bit of a [modern CMake approach](https://www.youtube.com/watch?v=eC9-iRN2b04). To achieve that, the minimum version of CMake was bumped to 3. The idea was to:

- remove compiler specific flags;
- avoid global project modifiers (for example, *include_directories*);
- avoid globs (those can be a pain when working with build caches).

I also added a **gitignore** file (to help on *out-of-source* builds) and some extra information of the **README** file.